### PR TITLE
Let the child process inherit the parent's std{out,err}

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
-use std::{env, fs, thread};
+use std::{env, fs};
 use std::collections::HashSet;
-use std::io::{BufRead, BufReader};
-use std::process::{Command, Stdio};
+use std::process::{Command};
 use owo_colors::{OwoColorize};
 
 const QUERY: &str = "home.packages";

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,24 +77,9 @@ fn main() {
     // https://stackoverflow.com/a/49063262
     let mut child = Command::new("home-manager")
         .arg("switch")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
         .spawn()
         .expect("Should able to run home-manager switch");
     println!("Running home-manager switch: PID {}", child.id());
-
-    let stdout = BufReader::new(child.stdout.take().expect("Child process should have stdout"));
-    let stderr = BufReader::new(child.stderr.take().expect("Child process should have stderr"));
-
-    let thread = thread::spawn(move || {
-        stderr.lines().for_each(
-            |line| println!("{}", line.unwrap())
-        );
-    });
-    stdout.lines().for_each(
-        |line| println!("{}", line.unwrap())
-    );
-    thread.join().unwrap();
 
     if child.wait().unwrap().success() {
         println!("{}", "Successfully updated home.nix and activated generation".green().bold());


### PR DESCRIPTION
I haven't tested this, but if you're piping home-manager's std{out,err} to pipes just to print them as is afterwards, then you don't need pipes at all. POSIX processes inherit their parent's std{in,out,err} so the spawned home-manager should just print to the same output than your program